### PR TITLE
Remove rialto-etl from repos.yml

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -59,8 +59,6 @@ status:
 ---
 repo: sul-dlss/preservation_robots
 ---
-repo: sul-dlss/rialto-etl
----
 repo: sul-dlss/robot-console
 ---
 repo: sul-dlss/sdr-api


### PR DESCRIPTION
We are decommissioning RIALTO, so no longer need to deploy updates.